### PR TITLE
add uranium page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 2019 MolSSI Software Summer School
 
-This repo contains files for a logistics website for the 2019 MolSSI Software Summer School.
+This repo contains files for a periodic table
 
 This website uses the `minima` theme.

--- a/elements/uranium.md
+++ b/elements/uranium.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: Uranium
+---
+
+Symbol = U
+AN = 92
+mass = 238.03 
+
+
+


### PR DESCRIPTION
This pull request adds a page to the periodic table for the element Uranium 